### PR TITLE
Add option to use GPS location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6 (2022-09-30)
+### Changed
+- Add option to use a GPS location for the object creation that's used to retrieve the warncell ID
+
 ## 1.0.5 (2022-01-23)
 ### Changed
 - Revert changes done in 1.0.4

--- a/README.md
+++ b/README.md
@@ -69,9 +69,14 @@ Last update: 2020-04-18 17:57:29.274000+00:00
 - **`__init__(identifier)`**  
   Create a new weather warnings API class instance  
   
-  The `identifier` can either be a so called `warncell id` (int) or a `warncell name` (str). It is heavily advised to use `warncell id` because `warncell name` is not unique in some cases.  
-  A list auf valid warncell ids and names can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.html).  
+  The `identifier` can either be a so called `warncell id` (int), a `warncell name` (str) or a `gps location` (tuple). 
+  It is heavily advised to use `warncell id` over `warncell name` because the name is not unique in some cases. The 
+  `gps location` consists of the latitude and longitude in this order. Keeping this order for the tuple is important for
+  the query to work correctly.  
+
+  A list auf valid warncell ids and names can be found [here](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_warncellids_csv.html). 
   Some of the warncells are outdated but still listed. If init fails search the list for a similar sounding warncell.  
+
   Method `update()` is automatically called at the end of a successfull init.  
 
 - **`update()`**  

--- a/tests/test_weatherwarnings.py
+++ b/tests/test_weatherwarnings.py
@@ -8,6 +8,8 @@ MIN_WARNING_LEVEL = 0  # 0 = no warning
 MAX_WARNING_LEVEL = 4  # 4 = extreme weather
 TIME_TOLERANCE = 5  # seconds
 
+GPS_LOCATION = (47.89523367441655, 10.06151536620045)
+
 WARNCELL_ID_CITY = 808436003
 WARNCELL_NAME_CITY = "Gemeinde Aichstetten"
 WARNCELL_ID_COUNTY = 106439000
@@ -94,6 +96,23 @@ def test_sea():
     assert dwd.data_valid
     assert dwd.warncell_id == WARNCELL_ID_SEA
     assert dwd.warncell_name == WARNCELL_NAME_SEA
+    start_time = datetime.datetime.now(
+        datetime.timezone.utc
+    ) - datetime.timedelta(0, TIME_TOLERANCE)
+    stop_time = start_time + datetime.timedelta(0, (2 * TIME_TOLERANCE))
+    assert start_time < dwd.last_update < stop_time
+    assert MIN_WARNING_LEVEL <= dwd.current_warning_level <= MAX_WARNING_LEVEL
+    assert MIN_WARNING_LEVEL <= dwd.expected_warning_level <= MAX_WARNING_LEVEL
+    assert isinstance(dwd.current_warnings, list)
+    assert isinstance(dwd.expected_warnings, list)
+
+
+def test_gps_location():
+    """Test determining the warncell id through gps."""
+    dwd = DwdWeatherWarningsAPI(GPS_LOCATION)
+    assert dwd.data_valid
+    assert dwd.warncell_id == WARNCELL_ID_CITY
+    assert dwd.warncell_name == WARNCELL_NAME_CITY
     start_time = datetime.datetime.now(
         datetime.timezone.utc
     ) - datetime.timedelta(0, TIME_TOLERANCE)


### PR DESCRIPTION
Hey, I looked into the matter I asked about and it was actually easier than I anticipated!! I don't know anything about this geography stuff but luckily the WFS API implemented a lot of functions from the GeoServer which do basically all the work.

This would be my idea of the change, basically only extending the existing API with the option to use a GPS location. The query stuff can be kept unchanged because the response from WFS is the same, if the GPS coordinates were valid and in a region that's covered. I'm not that experienced with Python so feel free to improve the code :) 

Getting this into the library and up on pypi would be awesome! My next project would be trying to extend the official Home Assistant integration that's using this library, that will be tough :D